### PR TITLE
Update common_functions.js

### DIFF
--- a/inst/rkward/plugins/common/common_functions.js
+++ b/inst/rkward/plugins/common/common_functions.js
@@ -3,6 +3,6 @@ function getDataframe(vars) {
     if (Array.isArray(vars)) {
         return vars.join().split('[[')[0];
     } else {
-        return vars.split('[[')[0];
+        return vars.toString().split('[[')[0];
     }
 }


### PR DESCRIPTION
The "split is not a function" error occurs when we call the split() method on a value that is not of type string. To solve the error, convert the value to a string using the toString() method before calling the split method or make sure to only call the split method on strings.

https://bobbyhadz.com/blog/javascript-typeerror-string-split-is-not-a-function#:~:text=The%20%22split%20is%20not%20a,the%20split%20method%20on%20strings.